### PR TITLE
Set policy CMP0167 to avoid warnings with CMake 3.30

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,11 @@ else()
   endif()
 endif()
 
+# Use BoostConfig module distributed by boost library instead of using FindBoost module distributed
+# by CMake
+if(POLICY CMP0167)
+  cmake_policy(SET CMP0167 NEW)
+endif()
 INCLUDE(${JRL_CMAKE_MODULES}/base.cmake)
 INCLUDE(${JRL_CMAKE_MODULES}/boost.cmake)
 INCLUDE(${JRL_CMAKE_MODULES}/ide.cmake)


### PR DESCRIPTION
CMake 3.30 don't package anymore the FindBoost.cmake file. Instead, it encourage to use the BoostModule.cmake distributed by Boost.

To avoid a warning message, we must set the CMP0167 policy to NEW.