### PR TITLE
Use devel instead of master

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ PyCppAD — Python bindings for CppAD Automatic Differentiation library
 
 <p align="center">
     <a href="https://opensource.org/licenses/BSD-3-Clause"><img src="https://img.shields.io/badge/License-BSD%203--Clause-green.svg" alt="License"/></a>
-    <a href="https://gitlab.laas.fr/Simple-Robotics/pycppad/commits/master"><img src="https://gitlab.laas.fr/Simple-Robotics/pycppad/badges/master/pipeline.svg" alt="Pipeline status" /></a>
-    <a href="http://projects.laas.fr/gepetto/doc/Simple-Robotics/pycppad/master/coverage/"><img src="https://gitlab.laas.fr/Simple-Robotics/pycppad/badges/master/coverage.svg?job=doc-coverage" alt="Coverage report" /></a>
+    <a href="https://gitlab.laas.fr/Simple-Robotics/pycppad/commits/devel"><img src="https://gitlab.laas.fr/Simple-Robotics/pycppad/badges/devel/pipeline.svg" alt="Pipeline status" /></a>
+    <a href="http://projects.laas.fr/gepetto/doc/Simple-Robotics/pycppad/devel/coverage/"><img src="https://gitlab.laas.fr/Simple-Robotics/pycppad/badges/devel/coverage.svg?job=doc-coverage" alt="Coverage report" /></a>
     <a href="https://anaconda.org/conda-forge/pycppad"><img src="https://img.shields.io/conda/dn/conda-forge/pycppad.svg" alt="Conda Downloads"/></a>
     <a href="https://anaconda.org/conda-forge/pycppad"><img src="https://img.shields.io/conda/vn/conda-forge/pycppad.svg" alt="Conda Version"/></a>
     <a href="https://badge.fury.io/py/pycppad"><img src="https://badge.fury.io/py/pycppad.svg" alt="PyPI version"></a>


### PR DESCRIPTION
In our past practices, we had two main branches:
- `devel`: work in progress
- `master`: stable release (default)

By default, user will clone `master`, the stable and tested version.

This workflow is no more mandatory:
- Our CI has improved, `devel` is more stable than before
- Most user doesn't compile from sources and use packages instead (pip, conda, nix, apt, ...)

Given these changes and the fact that several tools assume the default branch to be the work in progress one, we have decided to change the default branch to `devel`.

This means that when you clone our repository, you will now be working with the ongoing development version by default.