### PR TITLE
Don't use windows-2019 image since it will be deprecied

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [windows-2019]
+        os: [windows-latest]
         compiler:
           - cmd: cl
             cppad_codegen: OFF


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/12045